### PR TITLE
Rightnaming historic record

### DIFF
--- a/conference/index.html
+++ b/conference/index.html
@@ -145,7 +145,7 @@
 <li>Developing Scientific Software in Python  (Duncan Gray)</li>
 <li>Fun with App Engine 1.5.0  (Greg Darke)</li>
 <li>Hosting Python Web Applications  (Graham Dumpleton)</li>
-<li>How Python Evolves (and How You Can Help Make It Happen)  (Nick Coghlan)</li>
+<li>How Python Evolves (and How You Can Help Make It Happen)  (Alyssa Coghlan)</li>
 <li>Infinite 8-bit Platformer  (Chris McCormick)</li>
 <li>Networking Libraries in Python.  (Senthil Kumaran)</li>
 <li>Pants - Network Programming Made Easy  (Evan Davis)</li>
@@ -165,7 +165,7 @@
 <li>Easy site migration using Diazo and Funnelweb  (Adam Terrey)</li>
 <li>How to maintain big app stacks without losing your mind  (Dylan Jay)</li>
 <li>Introduction to the Geospatial Web with GeoDjango  (Javier Candeira)</li>
-<li>Panel: Python 3  (Nick Coghlan, Raymond Hettinger, Richard Jones)</li>
+<li>Panel: Python 3  (Alyssa Coghlan, Raymond Hettinger, Richard Jones)</li>
 <li>Panel: Python in the webs  (Malcolm Tredinnick, Russell Keith-Magee,
 Dylan Jay, Richard Jones)</li>
 <li>Pyramid: Lighter, faster, better web apps  (Dylan Jay)</li>

--- a/conference/schedule/event/12/index.html
+++ b/conference/schedule/event/12/index.html
@@ -124,7 +124,7 @@
 
 <h3 style="margin-top: 3px; margin-bottom: 3px;">How Python Evolves (and How You Can Help Make It Happen)</h3>
 
-<p><span style="white-space: nowrap; font-size: smaller; font-weight: bold; padding-left: 1em;"><a href="http://www.boredomandlaziness.org">Mr. Nick Coghlan</a> <sup><a href="../../../../profile/04f2/index.html" title="bio">bio</a></sup></span>
+<p><span style="white-space: nowrap; font-size: smaller; font-weight: bold; padding-left: 1em;"><a href="http://www.boredomandlaziness.org">Ms. Alyssa Coghlan</a> <sup><a href="../../../../profile/04f2/index.html" title="bio">bio</a></sup></span>
 <br/><span style="white-space: nowrap; padding-left: 1em; font-size: smaller; font-weight: bold;">30min &loz;&loz; Intermediate</span>
 <br/><span style="white-space: nowrap; padding-left: 1em; font-size: smaller; font-weight: bold;">Saturday 11:00am, Grand Lodge</span>
 <br/><span style="padding-left: 1em; font-size: smaller; font-weight: bold;">categories:

--- a/conference/schedule/event/16/index.html
+++ b/conference/schedule/event/16/index.html
@@ -124,14 +124,14 @@
 
 <h3 style="margin-top: 3px; margin-bottom: 3px;">Panel: Python 3</h3>
 
-<p><span style="white-space: nowrap; font-size: smaller; font-weight: bold; padding-left: 1em;">Mr. Anthony Baxter Esq. (<a href="http://www.google.com">Google</a>) <sup><a href="../../../../profile/0343a1/index.html" title="bio">bio</a></sup></span><span style="white-space: nowrap; font-size: smaller; font-weight: bold; ">, <a href="http://www.boredomandlaziness.org">Mr. Nick Coghlan</a> <sup><a href="../../../../profile/04f2/index.html" title="bio">bio</a></sup></span><span style="white-space: nowrap; font-size: smaller; font-weight: bold; ">, Raymond D Hettinger <sup><a href="../../../../profile/076248/index.html" title="bio">bio</a></sup></span><span style="white-space: nowrap; font-size: smaller; font-weight: bold; ">, Richard Jones</span>
+<p><span style="white-space: nowrap; font-size: smaller; font-weight: bold; padding-left: 1em;">Mr. Anthony Baxter Esq. (<a href="http://www.google.com">Google</a>) <sup><a href="../../../../profile/0343a1/index.html" title="bio">bio</a></sup></span><span style="white-space: nowrap; font-size: smaller; font-weight: bold; ">, <a href="http://www.boredomandlaziness.org">Ms. Alyssa Coghlan</a> <sup><a href="../../../../profile/04f2/index.html" title="bio">bio</a></sup></span><span style="white-space: nowrap; font-size: smaller; font-weight: bold; ">, Raymond D Hettinger <sup><a href="../../../../profile/076248/index.html" title="bio">bio</a></sup></span><span style="white-space: nowrap; font-size: smaller; font-weight: bold; ">, Richard Jones</span>
 <br/><span style="white-space: nowrap; padding-left: 1em; font-size: smaller; font-weight: bold;">45min &loz; Beginner</span>
 <br/><span style="white-space: nowrap; padding-left: 1em; font-size: smaller; font-weight: bold;">Saturday 01:10pm, Grand Lodge</span>
 <br/><span style="padding-left: 1em; font-size: smaller; font-weight: bold;">categories:
     
         <a href='../../../talks/index.html?filter=advocacy'>advocacy</a>, <a href='../../../talks/index.html?filter=language'>language</a>
     </span>
-<div style="padding-left: 2em;">This is a panel discussion in which Nick Coghlan, Raymond Hettinger and Richard Jones discuss the state of Python 3,
+<div style="padding-left: 2em;">This is a panel discussion in which Alyssa Coghlan, Raymond Hettinger and Richard Jones discuss the state of Python 3,
 <br/>some of the new features, the 3rd party adoption, migration strategies and open to the floor for questions.</div></p>
 
 <br/>

--- a/conference/schedule/ical/3407b6f2359860b47f7e71909f50d4ea/index.html
+++ b/conference/schedule/ical/3407b6f2359860b47f7e71909f50d4ea/index.html
@@ -178,7 +178,7 @@ URL:http://127.0.0.1:8000/2011/schedule/
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:How Python Evolves (and How You Can Help Make It Happen)
-DESCRIPTION:Room: Grand Lodge\nPresenters: Mr. Nick Coghlan\n30min Intermedi
+DESCRIPTION:Room: Grand Lodge\nPresenters: Ms. Alyssa Coghlan\n30min Intermedi
  ate\ncategories: \nThe CPython reference interpreter lies at the heart of a
   much wider Python ecosystem. The decisions that shape the future developme
  nt of CPython ripple out and have a broad impact on the entire Python commu
@@ -282,7 +282,7 @@ BEGIN:VEVENT
 SUMMARY:Panel: Python 3
 DESCRIPTION:Room: Grand Lodge\nPresenters: Mr. Anthony Baxter Esq.\, Mr. Nic
  k Coghlan\, Raymond D Hettinger\, Richard Jones\n45min Beginner\ncategories
- : \nThis is a panel discussion in which Nick Coghlan\, Raymond Hettinger an
+ : \nThis is a panel discussion in which Alyssa Coghlan\, Raymond Hettinger an
  d Richard Jones discuss the state of Python 3\,\nsome of the new features\,
   the 3rd party adoption\, migration strategies and open to the floor for qu
  estions.

--- a/conference/schedule/ical/index.html
+++ b/conference/schedule/ical/index.html
@@ -177,7 +177,7 @@ URL:http://127.0.0.1:8000/2011/schedule/
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:How Python Evolves (and How You Can Help Make It Happen)
-DESCRIPTION:Room: Grand Lodge\nPresenters: Mr. Nick Coghlan\n30min Intermedi
+DESCRIPTION:Room: Grand Lodge\nPresenters: Ms. Alyssa Coghlan\n30min Intermedi
  ate\ncategories: \nThe CPython reference interpreter lies at the heart of a
   much wider Python ecosystem. The decisions that shape the future developme
  nt of CPython ripple out and have a broad impact on the entire Python commu
@@ -281,7 +281,7 @@ BEGIN:VEVENT
 SUMMARY:Panel: Python 3
 DESCRIPTION:Room: Grand Lodge\nPresenters: Mr. Anthony Baxter Esq.\, Mr. Nic
  k Coghlan\, Raymond D Hettinger\, Richard Jones\n45min Beginner\ncategories
- : \nThis is a panel discussion in which Nick Coghlan\, Raymond Hettinger an
+ : \nThis is a panel discussion in which Alyssa Coghlan\, Raymond Hettinger an
  d Richard Jones discuss the state of Python 3\,\nsome of the new features\,
   the 3rd party adoption\, migration strategies and open to the floor for qu
  estions.

--- a/conference/schedule/index.html
+++ b/conference/schedule/index.html
@@ -383,7 +383,7 @@ Calendar Feed
         11:00am
         </td>
         <td  class="event30" id='E012'  onclick="mouseclick(this);"><span class="hidden"></span><span id='ICOS7' name="ICO12"
-            class='hidden'></span><a class="eventinfo" id='TT7' href='event/12/index.html'>How Python Evolves (and How You Can Help Make It Happen)</a><br/><span style="font-size: smaller; font-style: italic;">Mr. Nick Coghlan</span><br/>&loz;&loz;
+            class='hidden'></span><a class="eventinfo" id='TT7' href='event/12/index.html'>How Python Evolves (and How You Can Help Make It Happen)</a><br/><span style="font-size: smaller; font-style: italic;">Ms. Alyssa Coghlan</span><br/>&loz;&loz;
         </td>
         <td  class="event30" id='E013'  onclick="mouseclick(this);"><span class="hidden"></span><span id='ICOS8' name="ICO13"
             
@@ -416,7 +416,7 @@ Calendar Feed
         01:10pm
         </td>
         <td  class="event45" id='E016'  onclick="mouseclick(this);"><span class="hidden"></span><span id='ICOS13' name="ICO16"
-            class='hidden'></span><a class="eventinfo" id='TT13' href='event/16/index.html'>Panel: Python 3</a><br/><span style="font-size: smaller; font-style: italic;">Mr. Anthony Baxter Esq., Mr. Nick Coghlan, Raymond D Hettinger, Richard Jones</span><br/>&loz;
+            class='hidden'></span><a class="eventinfo" id='TT13' href='event/16/index.html'>Panel: Python 3</a><br/><span style="font-size: smaller; font-style: italic;">Mr. Anthony Baxter Esq., Ms. Alyssa Coghlan, Raymond D Hettinger, Richard Jones</span><br/>&loz;
         </td>
         <td  class="event45" id='E017'  onclick="mouseclick(this);"><span class="hidden"></span><span id='ICOS14' name="ICO17"
             

--- a/profile/04f2/index.html
+++ b/profile/04f2/index.html
@@ -7,7 +7,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <title>Mr. Nick Coghlan - PyCon Australia 2011 Sydney - August 20/21 - A Conference for the Australian Python Community</title>
+    <title>Ms. Alyssa Coghlan - PyCon Australia 2011 Sydney - August 20/21 - A Conference for the Australian Python Community</title>
     <link rel="stylesheet" type="text/css" href="../..//css/base.css" />
     <meta name="robots" content="index,follow" />
     
@@ -120,10 +120,10 @@
           <div id="content">
             
 
-    <div><a href="http://www.boredomandlaziness.org">Mr. Nick Coghlan</a> <sup><a href="index.html" title="bio">bio</a></sup></div>
-    <div style="margin-left: 4em;">Nick is a software developer for the Red Hat Engineering Operations team in Brisbane, Australia, working on various internal Red Hat systems.
+    <div><a href="http://www.boredomandlaziness.org">Ms. Alyssa Coghlan</a> <sup><a href="index.html" title="bio">bio</a></sup></div>
+    <div style="margin-left: 4em;">Alyssa is a software developer for the Red Hat Engineering Operations team in Brisbane, Australia, working on various internal Red Hat systems.
 
-He has been a long-time contributor to the development of the CPython reference interpreter, is the author or co-author of 3 accepted Python Enhancement Proposals (338, 343 and 366) and is a member of the Python Software Foundation.</div>
+She has been a long-time contributor to the development of the CPython reference interpreter, is the author or co-author of 3 accepted Python Enhancement Proposals (338, 343 and 366) and is a member of the Python Software Foundation.</div>
 
 
           </div>

--- a/sprints/index.html
+++ b/sprints/index.html
@@ -161,7 +161,7 @@ some part of Python better.</p>
 <div class="section" id="sprint-leaders">
 <h1>Sprint Leaders</h1>
 <dl class="docutils">
-<dt><strong>Nick Coghlan</strong></dt>
+<dt><strong>Alyssa Coghlan</strong></dt>
 <dd>Will lead those interested in contributing to Python core development, including new-comers. Please go to his talk at the conference for information about the many various ways in which you might be able to help.</dd>
 <dt><strong>Audrey Roy</strong></dt>
 <dd>Mediagoblin:  <a class="reference external" href="http://mediagoblin.org/">http://mediagoblin.org/</a></dd>


### PR DESCRIPTION
Alyssa Coghlan is an incredibly prominent contributor to the Python ecosystem, and changed her name in 2023 ([source](https://www.curiousefficiency.org/pages/about/)). IMHO, it is jarring for one of the few Python related resources on the internet bearing the old name to be a conference that espouses a set of inclusive values. 

I've prepared this PR to correct that without first asking Alyssa, but she has given her consent for this to be PR'd and merged.